### PR TITLE
App insights block request for livness and readiness probe

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -102,6 +102,7 @@ app.use(passport.initialize())
 app.use(passport.session())
 
 
+
 // // enable detailed API logging in dev env
 if (config.env === 'development') {
   expressWinston.requestWhitelist.push('body')
@@ -147,11 +148,15 @@ if (config.env !== 'test') {
 
 function removeStackTraces ( envelope, context ) {
  
-  console.log(envelope);
-  console.log(context);
-  
+  var data = envelope.data.baseData;  
+  if (data.url && data.url.includes("health") )
+  {
+      return false;
+  }
+
   return true;
 }
+
 
 appInsights.defaultClient.addTelemetryProcessor(removeStackTraces);
 

--- a/config/express.js
+++ b/config/express.js
@@ -145,9 +145,20 @@ if (config.env !== 'test') {
 }
 
 
+function removeStackTraces ( envelope, context ) {
+ 
+  console.log(envelope);
+  console.log(context);
+  
+  return true;
+}
+
+appInsights.defaultClient.addTelemetryProcessor(removeStackTraces);
+
+
 // error handler, send stacktrace only during development
 app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
-  // appInsights.defaultClient.trackException({exception: err})
+  appInsights.defaultClient.trackException({exception: err})
   res.status(err.status).json({
     message: err.isPublic ? err.message : httpStatus[err.status],
     stack: config.env === 'development' ? err.stack : {}

--- a/kubernetes/chronas-api-deployment.yml
+++ b/kubernetes/chronas-api-deployment.yml
@@ -14,6 +14,20 @@ spec:
         image: aumanjoa/chronas-api:214
         ports:
         - containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /v1/health
+            port: 80
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: 80
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 15  
         env:
         - name: MONGO_HOST
           valueFrom:

--- a/kubernetes/chronas-api-deployment.yml
+++ b/kubernetes/chronas-api-deployment.yml
@@ -18,7 +18,7 @@ spec:
           httpGet:
             path: /v1/health
             port: 80
-          initialDelaySeconds: 15
+          initialDelaySeconds: 35
           timeoutSeconds: 1
           periodSeconds: 15
         readinessProbe:


### PR DESCRIPTION
- added liveness and readiness probe
- the liveness and readiness probe should not be pushed to applicatio insights
