### PR TITLE
using multi stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,20 @@ ENV PORT=80
 # only copy package.json initially so that `RUN npm start` layer is recreated only
 # if there are changes in package.json
 ADD package.json .
-RUN npm install --silent
+RUN npm install
 # copy all file from current dir to /app in container
 COPY . .
-RUN npm run build --silent
+RUN npm run build
 
+WORKDIR /app/dist
+RUN npm install --production --silent
 
 # final stage for running the app
 FROM node:10-alpine
-COPY --from=builder /app/dist .
+# set /app directory as default working directory
+WORKDIR /app
+
+COPY --from=builder /app/dist /app/
 # expose port 80
 EXPOSE 80
 # cmd to start service

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ ENV PORT=80
 # only copy package.json initially so that `RUN npm start` layer is recreated only
 # if there are changes in package.json
 ADD package.json .
-RUN npm install
+RUN npm install --silent
 # copy all file from current dir to /app in container
 COPY . .
-RUN npm run build
+RUN npm run build --silent
 
 
 # final stage for running the app


### PR DESCRIPTION
this resolves issue #18 

### Important changes that need reviewing

I moved the build entirely to the container which reduces the coupling between the app and the environment it is built on, and makes starting out faster. (now e.g. you can get the app running by just cloning and building the container).

Though this required to install devDependencies (so that we can build) and that's why `production` had to be removed from npm install.

And final image is now 71.1mb.